### PR TITLE
Added a link to code of conduct and authors

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -174,6 +174,9 @@ This course was originally designed by Janne Blomqvist.
 
 In 2020 it was completely redesigned by a team of the following:
 
-* Authors:
+* Authors: Radovan Bast, Richard Darst, Anne Fouilloux, ...
 * Editor:
-* Testers and advisors:
+* Testers and advisors: Enrico Glerean
+
+We follow The Carpentries Code of Conduct: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
+


### PR DESCRIPTION
Added a link to code of conduct. There should be a contact email for reporting incidents.

Added some list of authors (sorted by surname) based on the commits to the repo, apologies if I missed anyone.

Maybe "editor" can be removed?