### PR TITLE
pandas: Add `-nc` option to wget

### DIFF
--- a/pandas.ipynb
+++ b/pandas.ipynb
@@ -66,7 +66,7 @@
     }
    ],
    "source": [
-    "!wget https://raw.githubusercontent.com/pandas-dev/pandas/master/doc/data/titanic.csv"
+    "!wget -nc https://raw.githubusercontent.com/pandas-dev/pandas/master/doc/data/titanic.csv"
    ]
   },
   {


### PR DESCRIPTION
- This prevents more and more copies of titanic.csv being downloaded.
- This is just a temporary measure - it should be refactored to not
  depend on Linux command line tools...
- Review: general check, is this a good idea, should we directly find
  a better solution?