### PR TITLE
Adjust color contrast to sphinx_rtd_theme

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -32,6 +32,7 @@ github_version = 'master/' # with trailing slash
 # ones.
 extensions = [
     'sphinx_lesson',
+    'sphinx_rtd_theme_ext_color_contrast',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Sphinx
 sphinx_rtd_theme
 myst_nb
 https://github.com/coderefinery/sphinx-lesson/archive/master.zip
+sphinx_rtd_theme_ext_color_contrast


### PR DESCRIPTION
- I found that sphinx_rtd_theme didn't meet accessibility guidelines
  for color contrast, so I made this package to work on it by
  overriding some CSS:
  https://github.com/AaltoSciComp/sphinx_rtd_theme_ext_color_contrast
- This isn't the work of a designer, I just increased saturation of
  some colors to hack around the problem.
- Advantage is this probably makes it better for presentations and
  teaching - less eye strain.
- Review: does the preview make sense?  Maybe we shouldn't merge right
  before a lesson...