### PR TITLE
Template of parallel episode

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -33,6 +33,7 @@ github_version = 'master/' # with trailing slash
 extensions = [
     'sphinx_lesson',
     'sphinx_rtd_theme_ext_color_contrast',
+    'sphinx.ext.todo',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/index.rst
+++ b/index.rst
@@ -55,6 +55,7 @@ to learn yourself as you need to.
    30 min   ; :doc:`dependencies`
    60 min   ; :doc:`packaging`
    ?? min   ; :doc:`scipy`
+   45 min   ; :doc:`parallel`
    ?? min   ; :doc:`pandas`
    ?? min   ; :doc:`libraries`
    ?? min   ; :doc:`binder`
@@ -74,6 +75,7 @@ to learn yourself as you need to.
    packaging
    scipy
    pandas
+   parallel
    libraries
    binder
 

--- a/parallel.rst
+++ b/parallel.rst
@@ -1,0 +1,81 @@
+Parallel programming
+====================
+
+.. questions::
+
+   - When you need more than one processor, what do you do?
+   - What are the limitations of How to use basic NumPy?
+
+.. objectives::
+
+   - Understand the major strategies of parallelizing code
+   - Understand mechanics of the ``multiprocessing`` package
+   - Know when to use more advanced packages
+
+
+
+Modes of parallelism
+--------------------
+
+.. todo::
+
+   - Richard
+
+
+
+Multithreading and the GIL
+--------------------------
+
+.. todo::
+
+   - Richard
+   - quick since not really used, but explain GIL
+
+
+
+``multiprocessing``
+-------------------
+
+.. todo::
+
+   - example
+   - Richard
+
+
+
+MPI
+---
+
+.. todo::
+
+   - Radovan
+
+
+
+Coupling to other languages
+---------------------------
+
+.. todo::
+
+   - OpenMP
+   - Radovan
+
+
+
+Dask and task queues
+--------------------
+
+.. todo::
+
+    - Radovan?
+
+
+
+See also
+--------
+
+
+.. keypoints::
+
+   - K1
+   - K2


### PR DESCRIPTION
- Basic outline of parallel episode, from #98
- Enable the builtin "todo" directive.  By default it doesn't appear
  in the output but can be configured to do so.
- Review: minimial, simple copy from the issue as a template to fill
  in, and will be revised later.