### PR TITLE
.github/workflows/sphinx: force_orphan = True

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -100,4 +100,4 @@ jobs:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _gh-pages/
-          #force_orphan: true
+          force_orphan: true


### PR DESCRIPTION
- Don't save all gh-pages histotry
- This is a PR, but since PRs also deploy, it is probably a null
  operation and will immediately come into effect anyway... there may
  sill be a better way though.
- I originally thought it was safer, now seems reliable enough it's
  not needed.  I wish we could keep just the last 5 commits or
  something, though...
- Review: is there any need for gh-pages history?