### PR TITLE
.github/workflows/sphinx: Make a strict warning CI check

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -4,6 +4,29 @@ name: sphinx
 on: [push, pull_request]
 
 jobs:
+
+  strict-warnings:
+    name: Strict warning check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - uses: ammaraskar/sphinx-problem-matcher@master
+      - name: Build Sphinx docs
+        run: |
+          # -W : warnings into errors
+          # -T : show full tracebacks on exceptions
+          # -q : quiet except warnings
+          # -n : nitpicky, warn about missing references
+          make dirhtml SPHINXOPTS='-q -W --keep-going -T -n'
+
+
   build-and-deploy:
     name: Build and gh-pages
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Run with strict warnings in a separate job (compared to the gh-pages
  build, which will be always deployed best-effort if the build
  doesn't hard-fail with an actual error).

- I'm not quite sure what the right semantics are here: is this too
  strict?  In one of my sites, because of includes and other matters,
  we always have warnings and I have given up trying to get rid of
  them completely.

- Now we might have a total of four sphinx problem-matchers, plus the
  whole thing be built four time... maybe this is getting excessive,
  and needs to be cut down some.

- Review: recommend detailed review since I'm not sure if this is the
  best way to do this, there is some duplication.  Does it belong here
  or a different workflow file?  Is there a way to give a more
  noticeable warning but not hard fail?  I just wanted something quick
  to test, so am submitting this.