### PR TITLE
Add websocket-client to the conda environment

### DIFF
--- a/software/environment.yml
+++ b/software/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - jupyterlab
   - notebook
   - ipywidgets
+  - websocket-client
   - requests
   - numpy
   - scipy


### PR DESCRIPTION
It was missing from the environment when I tried installing. Adding it should not cause a problem.