### PR TITLE
Pandas: don't discuss pivot_table 

### DIFF
--- a/content/pandas.rst
+++ b/content/pandas.rst
@@ -413,6 +413,30 @@ Exercises 3
         sns.catplot(x="bornCountry", col="category", data=subset_physchem, kind="count");
 
 
+Beyond the basics
+-----------------
+
+There is much more to Pandas than what we covered in this lesson. Whatever your
+needs are, chances are good there is a function somewhere in its `API
+<https://pandas.pydata.org/docs/>`__. And when there is not, you can always
+apply your own functions to the data using `.apply`::
+
+    from functools import lru_cache
+
+    @lru_cache
+    def fib(x):
+        """Compute Fibonacci numbers. The @lru_cache remembers values we
+        computed before, which speeds up this function a lot."""
+        if x < 0:
+            raise NotImplementedError('Not defined for negative values')
+        elif x < 2:
+            return x
+        else:
+            return fib(x - 2) + fib(x - 1)
+
+    df = pd.DataFrame({'Generation': np.arange(100)})
+    df['Number of Rabbits'] = df['Generation'].apply(fib)
+
 
 .. keypoints::
 


### PR DESCRIPTION
When I add something (#196) I should also take something away. I think that `.groupby` is in every way better than `.pivot_table` because:

 - The syntax is easier to understand
 - The result is in tidy data format, which we are trying to promote
 - In the exercise, `.pivot_table` requires a hack (adding a number column) whereas `.groupby` does not

So, in the interest of saving time, let's skip `.pivot_table` and only talk about `.groupby`.

Furthermore, I would like to skip `.apply` as is it only needed in very rare cases. In fact, the example in the material is pointless, as `.mean()` exists. There is almost always a buildin function that does what you want. Furthermore, it's a bit complicated to explain that on a dataframe, `.apply` operates column by column, whereas on a series, it operates value by value.