### PR TITLE
formatting one-liners in BASH and exchanging " with '

### DIFF
--- a/content/dependencies.rst
+++ b/content/dependencies.rst
@@ -188,8 +188,8 @@ Exercises 2
 
      Or use the one-liner if you have access to a terminal like bash
 
-     python -c "import numpy; print(numpy.__version__)"
-     python -c "import matplotlib;print(matplotlib.__version__)"
+      python -c 'import numpy; print(numpy.__version__)'
+      python -c 'import matplotlib;print(matplotlib.__version__)'
 
   4. Deactivate the environment::
 


### PR DESCRIPTION
one-liners were not  formatted, now two separate lines -->  copy-pasting the " into terminal on mac and wsl bash becomes wrong ", changed to ' to work