### PR TITLE
content/jupyter: Use timeit as first cell magic example

### DIFF
--- a/content/jupyter.ipynb
+++ b/content/jupyter.ipynb
@@ -201,13 +201,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In addition to raw cells, there are **magics**, which exist outside of Python.  They are a property of the runtime itself (in Python's case, they come from **IPython**.  For example, the following cell magic [%%bash](https://ipython.readthedocs.io/en/stable/interactive/magics.html#cellmagic-bash)  turns the cell into a shell script (may not work on all operating systems):"
+    "In addition to raw cells, there are **magics**, which exist outside of Python.  They are a property of the runtime itself (in Python's case, they come from **IPython**.  For example, the following cell magic [%%timeit](https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-timeit) will use the {py:mod}`timeit` module to time a cell by running it multiple times):"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "54.1 ms ± 993 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "for x in range(1000000):\n",
+    "    x**2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "Another example is [%%bash](https://ipython.readthedocs.io/en/stable/interactive/magics.html#cellmagic-bash) which will turn the cell into a shell script (This will only work on operating systems with the Bash shell installed - MacOS and Linux at least):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",


### PR DESCRIPTION
- Related: #64 (makes it slightly bettter but not fully fixing)
- Introduce %%timeit as first magic since %%bash doesn't work on all
  OSs.
- Not yet removing %%bash, I'd like to add another magic as an extra
  example to not make it just about %%timeit
- I think that %%prun is most likely option for another demo but it
  should have a longer example that gives a meaningful profile.
