### PR TITLE
adding vega_datasets to list of dependencies

### DIFF
--- a/software/environment.yml
+++ b/software/environment.yml
@@ -21,4 +21,5 @@ dependencies:
   - scalene
   - ruff
   - altair-all
+  - vega_datasets
   - xarray


### PR DESCRIPTION
vega_datasets contains example datasets which are used in the Vega-Altair gallery of examples

having this dependency would make this exercise
easier: https://aaltoscicomp.github.io/python-for-scicomp/plotting-vega-altair/#exercise-adapting-a-gallery-example